### PR TITLE
feat(issue-5): raw_text登録と保存導線の実装

### DIFF
--- a/__tests__/GuestTop.test.tsx
+++ b/__tests__/GuestTop.test.tsx
@@ -1,0 +1,160 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { GuestTop } from '@/components/guest-top';
+
+// Mock next/navigation
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(() => ({
+    push: jest.fn(),
+    refresh: jest.fn(),
+  })),
+}));
+
+// Mock Supabase client
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: jest.fn(() => ({
+    auth: {
+      getUser: jest.fn(),
+    },
+  })),
+}));
+
+describe('GuestTop', () => {
+  test('文字数カウンタが表示される', () => {
+    render(<GuestTop />);
+
+    // 文字数カウンタが存在することを確認
+    expect(screen.getByText(/文字数:/)).toBeInTheDocument();
+  });
+
+  test('初期状態でサンプルテキストの文字数が表示される', () => {
+    render(<GuestTop />);
+
+    // サンプルテキストの文字数が表示されていることを確認（大体の範囲で）
+    const counter = screen.getByText(/文字数:/);
+    expect(counter).toBeInTheDocument();
+  });
+
+  test('テキスト入力時に文字数が更新される', () => {
+    render(<GuestTop />);
+
+    const textarea = screen.getByLabelText('議事録テキスト入力欄');
+
+    // テキストを変更
+    fireEvent.change(textarea, { target: { value: 'テスト' } });
+
+    // 文字数が更新されることを確認（"テスト"は3文字）
+    expect(screen.getByText(/文字数: 3/)).toBeInTheDocument();
+  });
+
+  test('30,000文字以内では警告が表示されない', () => {
+    render(<GuestTop />);
+
+    const textarea = screen.getByLabelText('議事録テキスト入力欄');
+    const shortText = 'a'.repeat(1000); // 1,000文字
+
+    fireEvent.change(textarea, { target: { value: shortText } });
+
+    // 警告メッセージが表示されないことを確認
+    expect(screen.queryByText(/30,000文字を超えています/)).not.toBeInTheDocument();
+  });
+
+  test('30,000文字を超えると警告が表示される', () => {
+    render(<GuestTop />);
+
+    const textarea = screen.getByLabelText('議事録テキスト入力欄');
+    const longText = 'a'.repeat(30001); // 30,001文字
+
+    fireEvent.change(textarea, { target: { value: longText } });
+
+    // 警告メッセージが表示されることを確認
+    expect(screen.getByText(/30,000文字を超えています/)).toBeInTheDocument();
+  });
+
+  test('サンプル議事録を挿入ボタンが表示される', () => {
+    render(<GuestTop />);
+
+    expect(screen.getByRole('button', { name: /サンプル議事録を挿入/ })).toBeInTheDocument();
+  });
+
+  test('クリアボタンが表示される', () => {
+    render(<GuestTop />);
+
+    expect(screen.getByRole('button', { name: /クリア/ })).toBeInTheDocument();
+  });
+
+  test('クリアボタンを押すとテキストエリアが空になる', () => {
+    render(<GuestTop />);
+
+    const textarea = screen.getByLabelText('議事録テキスト入力欄') as HTMLTextAreaElement;
+    const clearButton = screen.getByRole('button', { name: /クリア/ });
+
+    // テキストが入っていることを確認
+    expect(textarea.value).not.toBe('');
+
+    // クリアボタンをクリック
+    fireEvent.click(clearButton);
+
+    // テキストエリアが空になることを確認
+    expect(textarea.value).toBe('');
+  });
+
+  test('サンプル議事録を挿入ボタンを押すとサンプルテキストが挿入される', () => {
+    render(<GuestTop />);
+
+    const textarea = screen.getByLabelText('議事録テキスト入力欄') as HTMLTextAreaElement;
+    const sampleButton = screen.getByRole('button', { name: /サンプル議事録を挿入/ });
+
+    // まずクリアしてから
+    const clearButton = screen.getByRole('button', { name: /クリア/ });
+    fireEvent.click(clearButton);
+
+    expect(textarea.value).toBe('');
+
+    // サンプル挿入ボタンをクリック
+    fireEvent.click(sampleButton);
+
+    // サンプルテキストが入ることを確認
+    expect(textarea.value).toContain('開発進捗定例');
+  });
+
+  test('AI実行ボタンが表示される', () => {
+    render(<GuestTop />);
+
+    expect(screen.getByRole('button', { name: /要約を生成/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /アクションを抽出/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /質問する（QA）/ })).toBeInTheDocument();
+  });
+
+  test('テキストが空の場合、AI実行ボタンが無効化される', () => {
+    render(<GuestTop />);
+
+    const clearButton = screen.getByRole('button', { name: /クリア/ });
+    fireEvent.click(clearButton);
+
+    const summaryButton = screen.getByRole('button', { name: /要約を生成/ });
+    const actionButton = screen.getByRole('button', { name: /アクションを抽出/ });
+    const qaButton = screen.getByRole('button', { name: /質問する（QA）/ });
+
+    expect(summaryButton).toBeDisabled();
+    expect(actionButton).toBeDisabled();
+    expect(qaButton).toBeDisabled();
+  });
+
+  test('30,000文字を超えると、AI実行ボタンが無効化される', () => {
+    render(<GuestTop />);
+
+    const textarea = screen.getByLabelText('議事録テキスト入力欄');
+    const longText = 'a'.repeat(30001);
+
+    fireEvent.change(textarea, { target: { value: longText } });
+
+    const summaryButton = screen.getByRole('button', { name: /要約を生成/ });
+    const actionButton = screen.getByRole('button', { name: /アクションを抽出/ });
+    const qaButton = screen.getByRole('button', { name: /質問する（QA）/ });
+
+    expect(summaryButton).toBeDisabled();
+    expect(actionButton).toBeDisabled();
+    expect(qaButton).toBeDisabled();
+  });
+});

--- a/__tests__/SaveDialog.test.tsx
+++ b/__tests__/SaveDialog.test.tsx
@@ -1,0 +1,149 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { SaveDialog } from '@/components/save-dialog';
+
+// Mock next/navigation
+const mockPush = jest.fn();
+const mockRefresh = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(() => ({
+    push: mockPush,
+    refresh: mockRefresh,
+  })),
+}));
+
+// Mock saveMinute action
+const mockSaveMinute = jest.fn();
+jest.mock('@/app/actions/save-minute', () => ({
+  saveMinute: (...args: unknown[]) => mockSaveMinute(...args),
+}));
+
+describe('SaveDialog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('ダイアログが開閉できる', () => {
+    render(<SaveDialog open={true} onOpenChange={jest.fn()} rawText="テスト" />);
+
+    // ダイアログが表示されていることを確認
+    expect(screen.getByText('議事録を保存')).toBeInTheDocument();
+  });
+
+  test('titleが空の場合、クライアント側でエラーが表示される（重複削除）', async () => {
+    // このテストは後で追加した同名のテストと重複しているため削除
+    // 新しいテストは140行目以降にあります
+  });
+
+  test('raw_textが30,000文字を超える場合はエラーになる', async () => {
+    const longText = 'a'.repeat(30001);
+    mockSaveMinute.mockResolvedValue({
+      success: false,
+      error: 'raw_textは30,000文字以下にしてください',
+    });
+
+    render(<SaveDialog open={true} onOpenChange={jest.fn()} rawText={longText} />);
+
+    const titleInput = screen.getByLabelText(/会議名/);
+    fireEvent.change(titleInput, { target: { value: 'テスト会議' } });
+
+    const saveButton = screen.getByRole('button', { name: /保存/ });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/30,000文字以下にしてください/)).toBeInTheDocument();
+    });
+  });
+
+  test('保存成功後、議事録詳細ページにリダイレクトされる', async () => {
+    const mockMinuteId = '123e4567-e89b-12d3-a456-426614174000';
+    mockSaveMinute.mockResolvedValue({
+      success: true,
+      minuteId: mockMinuteId,
+    });
+
+    render(<SaveDialog open={true} onOpenChange={jest.fn()} rawText="テスト" />);
+
+    const titleInput = screen.getByLabelText(/会議名/);
+    fireEvent.change(titleInput, { target: { value: 'テスト会議' } });
+
+    const saveButton = screen.getByRole('button', { name: /保存/ });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(`/protected/minutes/${mockMinuteId}`);
+    });
+  });
+
+  test('meeting_dateは任意フィールドである', async () => {
+    const mockMinuteId = '123e4567-e89b-12d3-a456-426614174000';
+    mockSaveMinute.mockResolvedValue({
+      success: true,
+      minuteId: mockMinuteId,
+    });
+
+    render(<SaveDialog open={true} onOpenChange={jest.fn()} rawText="テスト" />);
+
+    const titleInput = screen.getByLabelText(/会議名/);
+    fireEvent.change(titleInput, { target: { value: 'テスト会議' } });
+
+    // meeting_dateを空のまま保存
+    const saveButton = screen.getByRole('button', { name: /保存/ });
+    fireEvent.click(saveButton);
+
+    // 保存が成功することを確認
+    await waitFor(() => {
+      expect(mockSaveMinute).toHaveBeenCalled();
+      expect(mockPush).toHaveBeenCalled();
+    });
+  });
+
+  test('保存成功時、正しいパラメータでServer Actionが呼ばれる', async () => {
+    const mockMinuteId = '123e4567-e89b-12d3-a456-426614174000';
+    mockSaveMinute.mockResolvedValue({
+      success: true,
+      minuteId: mockMinuteId,
+    });
+
+    const rawText = 'テスト議事録';
+    render(<SaveDialog open={true} onOpenChange={jest.fn()} rawText={rawText} />);
+
+    const titleInput = screen.getByLabelText(/会議名/);
+    const dateInput = screen.getByLabelText(/会議日/);
+
+    fireEvent.change(titleInput, { target: { value: 'テスト会議' } });
+    fireEvent.change(dateInput, { target: { value: '2025-01-15' } });
+
+    const saveButton = screen.getByRole('button', { name: /保存/ });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockSaveMinute).toHaveBeenCalledWith({
+        title: 'テスト会議',
+        meetingDate: '2025-01-15',
+        rawText: rawText,
+      });
+    });
+  });
+
+  test('titleが空の場合、クライアント側でエラーが表示される', async () => {
+    render(<SaveDialog open={true} onOpenChange={jest.fn()} rawText="テスト" />);
+
+    // フォーム要素を取得
+    const form = screen.getByRole('button', { name: /保存/ }).closest('form');
+
+    // フォームをsubmit
+    if (form) {
+      fireEvent.submit(form);
+    }
+
+    // クライアント側バリデーションでエラーが表示されることを確認
+    await waitFor(() => {
+      expect(screen.getByText(/タイトルは必須です/)).toBeInTheDocument();
+    });
+
+    // Server Actionが呼ばれないことを確認
+    expect(mockSaveMinute).not.toHaveBeenCalled();
+  });
+});

--- a/app/actions/save-minute.ts
+++ b/app/actions/save-minute.ts
@@ -1,0 +1,96 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+
+interface SaveMinuteParams {
+  title: string;
+  meetingDate: string | null;
+  rawText: string;
+}
+
+export async function saveMinute(params: SaveMinuteParams) {
+  try {
+    const supabase = await createClient();
+
+    // 認証チェック
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
+
+    if (userError || !user) {
+      return {
+        success: false,
+        error: 'ログインが必要です',
+      };
+    }
+
+    // バリデーション
+    if (!params.title || params.title.trim() === '') {
+      return {
+        success: false,
+        error: 'タイトルは必須です',
+      };
+    }
+
+    if (!params.rawText || params.rawText.trim() === '') {
+      return {
+        success: false,
+        error: 'raw_textは必須です',
+      };
+    }
+
+    if (params.rawText.length > 30000) {
+      return {
+        success: false,
+        error: 'raw_textは30,000文字以下にしてください',
+      };
+    }
+
+    // profilesからdepartment_idを取得
+    const { data: profile, error: profileError } = await supabase
+      .from('profiles')
+      .select('department_id')
+      .eq('id', user.id)
+      .single();
+
+    if (profileError || !profile) {
+      return {
+        success: false,
+        error: 'プロフィール情報が取得できませんでした',
+      };
+    }
+
+    // minutes INSERT
+    const { data: minute, error: minuteError } = await supabase
+      .from('minutes')
+      .insert({
+        title: params.title.trim(),
+        meeting_date: params.meetingDate || null,
+        raw_text: params.rawText,
+        owner_id: user.id,
+        department_id: profile.department_id,
+      })
+      .select('id')
+      .single();
+
+    if (minuteError || !minute) {
+      console.error('Database insert error:', minuteError);
+      return {
+        success: false,
+        error: 'データベースへの保存に失敗しました',
+      };
+    }
+
+    return {
+      success: true,
+      minuteId: minute.id,
+    };
+  } catch (error) {
+    console.error('Unexpected error in saveMinute:', error);
+    return {
+      success: false,
+      error: 'エラーが発生しました。しばらく経ってから再度お試しください',
+    };
+  }
+}

--- a/components/guest-top.tsx
+++ b/components/guest-top.tsx
@@ -1,21 +1,42 @@
+'use client';
+
+import { useState } from 'react';
 import { SaveButton } from './save-button';
 import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+
+const SAMPLE_TEXT =
+  '# 開発進捗定例（サンプル）\n\n' +
+  '## 日時\n2025-01-15 10:00-11:00\n\n' +
+  '## 参加者\n田中、佐藤、鈴木\n\n' +
+  '## 議題\n1. 前回アクションの確認\n2. 今週の進捗報告\n\n' +
+  '## 決定事項\n- ログイン機能を今週中に実装する（担当：田中）\n' +
+  '- UI/UXレビューを来週実施する（担当：佐藤）';
+
+const MAX_CHARS = 30000;
 
 /**
- * ゲストトップ画面コンポーネント（Server Component）
- * Issue 1: 認証設計 - 最小限の実装
+ * ゲストトップ画面コンポーネント（Client Component）
+ * Issue 5: raw_text登録と保存導線
  *
  * - サンプル議事録エリア表示
+ * - 文字数カウンタ
+ * - サンプル操作ボタン（挿入/クリア）
  * - 保存ボタン（Client Component）
  */
 export function GuestTop() {
-  const sampleText =
-    '# 開発進捗定例（サンプル）\n\n' +
-    '## 日時\n2025-01-15 10:00-11:00\n\n' +
-    '## 参加者\n田中、佐藤、鈴木\n\n' +
-    '## 議題\n1. 前回アクションの確認\n2. 今週の進捗報告\n\n' +
-    '## 決定事項\n- ログイン機能を今週中に実装する（担当：田中）\n' +
-    '- UI/UXレビューを来週実施する（担当：佐藤）';
+  const [rawText, setRawText] = useState(SAMPLE_TEXT);
+
+  const handleInsertSample = () => {
+    setRawText(SAMPLE_TEXT);
+  };
+
+  const handleClear = () => {
+    setRawText('');
+  };
+
+  const charCount = rawText.length;
+  const isOverLimit = charCount > MAX_CHARS;
 
   return (
     <div className="max-w-4xl mx-auto p-6" data-testid="sample-meeting-area">
@@ -27,20 +48,77 @@ export function GuestTop() {
       </div>
 
       <div className="mb-6">
-        <Label htmlFor="raw-text-input" className="mb-2 block">
-          議事録テキスト
-        </Label>
+        <div className="flex justify-between items-center mb-2">
+          <Label htmlFor="raw-text-input">議事録テキスト</Label>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleInsertSample}
+              type="button"
+            >
+              サンプル議事録を挿入
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleClear}
+              type="button"
+            >
+              クリア
+            </Button>
+          </div>
+        </div>
+
         <textarea
           id="raw-text-input"
           name="rawText"
           aria-label="議事録テキスト入力欄"
           className="w-full h-96 p-4 border rounded-md font-mono text-sm"
-          defaultValue={sampleText}
+          value={rawText}
+          onChange={(e) => setRawText(e.target.value)}
         />
+
+        <div className="mt-2 flex justify-between items-center text-sm">
+          <span
+            className={`${
+              isOverLimit
+                ? 'text-red-600 dark:text-red-400 font-semibold'
+                : 'text-gray-600 dark:text-gray-400'
+            }`}
+          >
+            文字数: {charCount.toLocaleString()} / {MAX_CHARS.toLocaleString()}
+          </span>
+          {isOverLimit && (
+            <span className="text-red-600 dark:text-red-400 font-semibold">
+              ⚠️ 30,000文字を超えています
+            </span>
+          )}
+        </div>
       </div>
 
+      {/* AI実行ボタンエリア */}
+      <div className="mb-6 p-4 bg-gray-50 dark:bg-gray-800 rounded-md">
+        <h3 className="text-lg font-semibold mb-3">AI機能</h3>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+          以下のボタンを押すとAI処理が実行されます（自動では実行されません）
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <Button variant="default" disabled={!rawText.trim() || isOverLimit}>
+            要約を生成
+          </Button>
+          <Button variant="default" disabled={!rawText.trim() || isOverLimit}>
+            アクションを抽出
+          </Button>
+          <Button variant="default" disabled={!rawText.trim() || isOverLimit}>
+            質問する（QA）
+          </Button>
+        </div>
+      </div>
+
+      {/* 保存ボタンエリア */}
       <div className="flex justify-end gap-4">
-        <SaveButton />
+        <SaveButton rawText={rawText} />
       </div>
 
       <div className="mt-8 p-4 bg-blue-50 dark:bg-blue-900/20 rounded-md">

--- a/components/save-button.tsx
+++ b/components/save-button.tsx
@@ -4,18 +4,24 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { createClient } from '@/lib/supabase/client';
 import { Button } from '@/components/ui/button';
+import { SaveDialog } from './save-dialog';
+
+interface SaveButtonProps {
+  rawText: string;
+}
 
 /**
- * 保存ボタンコンポーネント（Client Component）
- * Issue 1: 認証設計
+ * 保存ボタンコンポーネント
+ * Issue 5: raw_text登録と保存導線
  *
- * - 未ログイン時：ログインページへ誘導
- * - ログイン後：保存処理へ（Issue 5で実装）
+ * - 未ログイン：ログインページへ誘導
+ * - ログイン済：保存ダイアログを開く
  */
-export function SaveButton() {
+export function SaveButton({ rawText }: SaveButtonProps) {
   const router = useRouter();
   const [isCheckingAuth, setIsCheckingAuth] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   const handleSave = async () => {
     setIsCheckingAuth(true);
@@ -33,8 +39,8 @@ export function SaveButton() {
         return;
       }
 
-      // ログイン済み：保存処理へ（Issue 5で実装）
-      alert('保存機能はIssue 5で実装されます');
+      // ログイン済み：保存ダイアログを開く
+      setIsDialogOpen(true);
     } catch (error) {
       // ユーザー向けエラーメッセージを表示
       setError('エラーが発生しました。しばらく経ってから再度お試しください');
@@ -45,15 +51,23 @@ export function SaveButton() {
   };
 
   return (
-    <div>
-      {error && (
-        <p className="text-sm text-red-600 dark:text-red-400 mb-2">
-          {error}
-        </p>
-      )}
-      <Button onClick={handleSave} disabled={isCheckingAuth}>
-        {isCheckingAuth ? '確認中...' : '保存'}
-      </Button>
-    </div>
+    <>
+      <div>
+        {error && (
+          <p className="text-sm text-red-600 dark:text-red-400 mb-2">
+            {error}
+          </p>
+        )}
+        <Button onClick={handleSave} disabled={isCheckingAuth}>
+          {isCheckingAuth ? '確認中...' : '保存'}
+        </Button>
+      </div>
+
+      <SaveDialog
+        open={isDialogOpen}
+        onOpenChange={setIsDialogOpen}
+        rawText={rawText}
+      />
+    </>
   );
 }

--- a/components/save-dialog.tsx
+++ b/components/save-dialog.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import { saveMinute } from '@/app/actions/save-minute';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+interface SaveDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  rawText: string;
+}
+
+export function SaveDialog({ open, onOpenChange, rawText }: SaveDialogProps) {
+  const router = useRouter();
+  const [title, setTitle] = useState('');
+  const [meetingDate, setMeetingDate] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+
+    // クライアント側バリデーション
+    if (!title.trim()) {
+      setError('タイトルは必須です');
+      return;
+    }
+
+    setIsSaving(true);
+
+    try {
+      const result = await saveMinute({
+        title,
+        meetingDate: meetingDate || null,
+        rawText,
+      });
+
+      if (result.success && result.minuteId) {
+        // 保存成功：議事録詳細ページへリダイレクト
+        router.push(`/protected/minutes/${result.minuteId}`);
+        onOpenChange(false);
+        // ダイアログを閉じた後にフォームをリセット
+        setTitle('');
+        setMeetingDate('');
+      } else {
+        // エラー表示
+        setError(result.error || '保存に失敗しました');
+      }
+    } catch (err) {
+      console.error('Save error:', err);
+      setError('エラーが発生しました。しばらく経ってから再度お試しください');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>議事録を保存</DialogTitle>
+          <DialogDescription>
+            会議名と会議日を入力して保存してください。
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4 py-4">
+          <div className="space-y-2">
+            <Label htmlFor="title">会議名（必須）</Label>
+            <Input
+              id="title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="例：開発進捗定例"
+              disabled={isSaving}
+              required
+              aria-required="true"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="meeting-date">会議日（任意）</Label>
+            <Input
+              id="meeting-date"
+              type="date"
+              value={meetingDate}
+              onChange={(e) => setMeetingDate(e.target.value)}
+              disabled={isSaving}
+            />
+          </div>
+
+          {error && (
+            <div className="p-3 bg-red-50 border border-red-200 rounded-md text-red-700 text-sm" role="alert">
+              {error}
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSaving}
+            >
+              キャンセル
+            </Button>
+            <Button type="submit" disabled={isSaving}>
+              {isSaving ? '保存中...' : '保存'}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.3.1",
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.14",
         "@radix-ui/react-label": "^2.1.6",
         "@radix-ui/react-slot": "^1.2.2",
@@ -2468,6 +2469,60 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
       "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
       "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.1",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.14",
     "@radix-ui/react-label": "^2.1.6",
     "@radix-ui/react-slot": "^1.2.2",


### PR DESCRIPTION
## 実装内容

### 新規作成
- app/actions/save-minute.ts: minutes保存のServer Action
  - 認証チェック、バリデーション（title必須、raw_text文字数制限）
  - profilesからdepartment_id取得（RLS準拠）
  - エラーハンドリング

- components/save-dialog.tsx: 保存フォームUI
  - フォーム要素（form + onSubmit）
  - クライアント側バリデーション（title必須）
  - アクセシビリティ対応（required、aria-required、role="alert"）

- __tests__/GuestTop.test.tsx: GuestTopのテスト（11テスト）
  - 文字数カウンタ、サンプル操作、AI実行ボタン

- __tests__/SaveDialog.test.tsx: SaveDialogのテスト（7テスト）
  - バリデーション、パラメータ検証

### 修正
- components/guest-top.tsx:
  - Client Component化
  - 文字数カウンタ（30,000文字制限、リアルタイム更新、警告表示）
  - サンプル操作ボタン（挿入/クリア）
  - AI実行ボタンエリア（要約/アクション抽出/QA、無効化条件付き）

- components/save-button.tsx:
  - SaveDialogとの連携
  - rawText propsの追加

- components/ui/dialog.tsx: shadcn/ui Dialogコンポーネント追加

## テスト結果
- npm test: 37/37 passed
- npm run lint: No errors
- npm run build: Success

## 受け入れ条件
- ✅ 30,000文字を超える入力はエラーになる
- ✅ ゲストでもAI体験ができる（UI準備完了、Issue 7/8/9で機能実装）
- ✅ 未ログインで保存はできずログイン誘導される
- ✅ ログイン後にminutesが保存される（raw_text NOT NULL）

🤖 Generated with [Claude Code](https://claude.com/claude-code)