### PR TITLE
feat(issue-10): 議事録検索機能を実装

### DIFF
--- a/__tests__/MinutesListPage.test.tsx
+++ b/__tests__/MinutesListPage.test.tsx
@@ -5,11 +5,13 @@ import MinutesListPage from '@/app/protected/minutes/page';
 // Mock next/navigation
 const mockPush = jest.fn();
 const mockRedirect = jest.fn();
+const mockSearchParams = new URLSearchParams();
 
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(() => ({
     push: mockPush,
   })),
+  useSearchParams: jest.fn(() => mockSearchParams),
   redirect: (url: string) => {
     mockRedirect(url);
     throw new Error(`REDIRECT: ${url}`);
@@ -41,7 +43,7 @@ describe('MinutesListPage', () => {
     });
 
     await expect(async () => {
-      await MinutesListPage();
+      await MinutesListPage({ searchParams: Promise.resolve({}) });
     }).rejects.toThrow('REDIRECT: /auth/login');
 
     expect(mockRedirect).toHaveBeenCalledWith('/auth/login');
@@ -53,16 +55,20 @@ describe('MinutesListPage', () => {
       error: null,
     });
 
-    mockFrom.mockReturnValue({
-      select: jest.fn().mockReturnValue({
-        order: jest.fn().mockResolvedValue({
-          data: [],
-          error: null,
-        }),
-      }),
+    const mockQuery = {
+      select: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      ilike: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      lte: jest.fn().mockReturnThis(),
+    };
+    mockQuery.order.mockResolvedValue({
+      data: [],
+      error: null,
     });
+    mockFrom.mockReturnValue(mockQuery);
 
-    const result = await MinutesListPage();
+    const result = await MinutesListPage({ searchParams: Promise.resolve({}) });
     const { container } = render(result);
 
     expect(container).toBeInTheDocument();
@@ -80,25 +86,31 @@ describe('MinutesListPage', () => {
         title: 'テスト会議1',
         meeting_date: '2025-01-15',
         created_at: '2025-01-15T10:00:00Z',
+        raw_text: 'テスト議事録1',
       },
       {
         id: '2',
         title: 'テスト会議2',
         meeting_date: null,
         created_at: '2025-01-14T10:00:00Z',
+        raw_text: 'テスト議事録2',
       },
     ];
 
-    mockFrom.mockReturnValue({
-      select: jest.fn().mockReturnValue({
-        order: jest.fn().mockResolvedValue({
-          data: mockMinutes,
-          error: null,
-        }),
-      }),
+    const mockQuery = {
+      select: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      ilike: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      lte: jest.fn().mockReturnThis(),
+    };
+    mockQuery.order.mockResolvedValue({
+      data: mockMinutes,
+      error: null,
     });
+    mockFrom.mockReturnValue(mockQuery);
 
-    const result = await MinutesListPage();
+    const result = await MinutesListPage({ searchParams: Promise.resolve({}) });
     render(result);
 
     expect(screen.getByText('テスト会議1')).toBeInTheDocument();
@@ -117,19 +129,24 @@ describe('MinutesListPage', () => {
         title: 'テスト会議',
         meeting_date: '2025-01-15',
         created_at: '2025-01-15T10:00:00Z',
+        raw_text: 'テスト議事録',
       },
     ];
 
-    mockFrom.mockReturnValue({
-      select: jest.fn().mockReturnValue({
-        order: jest.fn().mockResolvedValue({
-          data: mockMinutes,
-          error: null,
-        }),
-      }),
+    const mockQuery = {
+      select: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      ilike: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      lte: jest.fn().mockReturnThis(),
+    };
+    mockQuery.order.mockResolvedValue({
+      data: mockMinutes,
+      error: null,
     });
+    mockFrom.mockReturnValue(mockQuery);
 
-    const result = await MinutesListPage();
+    const result = await MinutesListPage({ searchParams: Promise.resolve({}) });
     render(result);
 
     const link = screen.getByRole('link', { name: /テスト会議/ });
@@ -142,16 +159,20 @@ describe('MinutesListPage', () => {
       error: null,
     });
 
-    mockFrom.mockReturnValue({
-      select: jest.fn().mockReturnValue({
-        order: jest.fn().mockResolvedValue({
-          data: [],
-          error: null,
-        }),
-      }),
+    const mockQuery = {
+      select: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      ilike: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      lte: jest.fn().mockReturnThis(),
+    };
+    mockQuery.order.mockResolvedValue({
+      data: [],
+      error: null,
     });
+    mockFrom.mockReturnValue(mockQuery);
 
-    const result = await MinutesListPage();
+    const result = await MinutesListPage({ searchParams: Promise.resolve({}) });
     render(result);
 
     expect(screen.getByText(/議事録がまだありません/)).toBeInTheDocument();

--- a/components/search-form.tsx
+++ b/components/search-form.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+
+/**
+ * 検索フォームコンポーネント（Client Component）
+ * Issue 10: 議事録検索機能
+ *
+ * - title（部分一致）
+ * - meeting_date範囲（from/to）
+ * - raw_text（部分一致キーワード）
+ * - URLパラメータで検索条件を管理
+ */
+export function SearchForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // 現在のURLパラメータから初期値を取得
+  const [title, setTitle] = useState(searchParams.get('title') || '');
+  const [dateFrom, setDateFrom] = useState(searchParams.get('dateFrom') || '');
+  const [dateTo, setDateTo] = useState(searchParams.get('dateTo') || '');
+  const [keyword, setKeyword] = useState(searchParams.get('keyword') || '');
+
+  const handleSearch = () => {
+    const params = new URLSearchParams();
+
+    if (title.trim()) {
+      params.set('title', title.trim());
+    }
+    if (dateFrom) {
+      params.set('dateFrom', dateFrom);
+    }
+    if (dateTo) {
+      params.set('dateTo', dateTo);
+    }
+    if (keyword.trim()) {
+      params.set('keyword', keyword.trim());
+    }
+
+    // URLパラメータを更新してページ遷移
+    router.push(`/protected/minutes?${params.toString()}`);
+  };
+
+  const handleClear = () => {
+    setTitle('');
+    setDateFrom('');
+    setDateTo('');
+    setKeyword('');
+    router.push('/protected/minutes');
+  };
+
+  // 現在の検索条件が存在するかチェック
+  const hasSearchConditions =
+    searchParams.get('title') ||
+    searchParams.get('dateFrom') ||
+    searchParams.get('dateTo') ||
+    searchParams.get('keyword');
+
+  return (
+    <div className="mb-6 p-4 bg-gray-50 dark:bg-gray-800 rounded-md">
+      <h2 className="text-lg font-semibold mb-4">検索条件</h2>
+
+      {/* 検索条件表示エリア */}
+      {hasSearchConditions && (
+        <div className="mb-4 p-3 bg-blue-50 dark:bg-blue-900/20 rounded-md border border-blue-200 dark:border-blue-800">
+          <p className="text-sm font-medium text-blue-900 dark:text-blue-100 mb-2">
+            現在の検索条件:
+          </p>
+          <ul className="text-sm text-blue-800 dark:text-blue-200 space-y-1">
+            {searchParams.get('title') && (
+              <li>タイトル: 「{searchParams.get('title')}」</li>
+            )}
+            {searchParams.get('dateFrom') && (
+              <li>開始日: {searchParams.get('dateFrom')}</li>
+            )}
+            {searchParams.get('dateTo') && (
+              <li>終了日: {searchParams.get('dateTo')}</li>
+            )}
+            {searchParams.get('keyword') && (
+              <li>キーワード: 「{searchParams.get('keyword')}」</li>
+            )}
+          </ul>
+        </div>
+      )}
+
+      <div className="space-y-4">
+        {/* タイトル検索 */}
+        <div>
+          <Label htmlFor="search-title" className="text-sm font-medium">
+            タイトル（部分一致）
+          </Label>
+          <Input
+            id="search-title"
+            type="text"
+            placeholder="例: 開発進捗"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="mt-1"
+          />
+        </div>
+
+        {/* 会議日範囲検索 */}
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <Label htmlFor="search-date-from" className="text-sm font-medium">
+              会議日（開始）
+            </Label>
+            <Input
+              id="search-date-from"
+              type="date"
+              value={dateFrom}
+              onChange={(e) => setDateFrom(e.target.value)}
+              className="mt-1"
+            />
+          </div>
+          <div>
+            <Label htmlFor="search-date-to" className="text-sm font-medium">
+              会議日（終了）
+            </Label>
+            <Input
+              id="search-date-to"
+              type="date"
+              value={dateTo}
+              onChange={(e) => setDateTo(e.target.value)}
+              className="mt-1"
+            />
+          </div>
+        </div>
+
+        {/* キーワード検索 */}
+        <div>
+          <Label htmlFor="search-keyword" className="text-sm font-medium">
+            本文キーワード（部分一致）
+          </Label>
+          <Input
+            id="search-keyword"
+            type="text"
+            placeholder="例: ログイン機能"
+            value={keyword}
+            onChange={(e) => setKeyword(e.target.value)}
+            className="mt-1"
+          />
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            議事録本文（raw_text）から検索します
+          </p>
+        </div>
+
+        {/* ボタンエリア */}
+        <div className="flex gap-3">
+          <Button variant="default" onClick={handleSearch}>
+            検索
+          </Button>
+          <Button variant="outline" onClick={handleClear}>
+            クリア
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- title/meeting_date/raw_textでの検索に対応
- URLパラメータで検索条件を管理（ブックマーク・共有可能）
- 検索条件表示エリアでUI上で現在の検索条件が明示
- 検索結果数の表示
- RLSにより部門内のみ検索可能
- Server Component（検索実行）とClient Component（フォーム）の適切な分離

🤖 Generated with [Claude Code](https://claude.com/claude-code)