### PR TITLE
feat(issue-33): 議事録一覧ページに使い方と注意事項を追加

### DIFF
--- a/app/protected/minutes/page.tsx
+++ b/app/protected/minutes/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from '@/lib/supabase/server';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { SearchForm } from '@/components/search-form';
+import { UsageGuide } from '@/components/usage-guide';
 import { Button } from '@/components/ui/button';
 import { ROUTES } from '@/lib/routes';
 
@@ -64,6 +65,15 @@ export default async function MinutesListPage({
 
   if (minutesError) {
     console.error('Failed to fetch minutes:', minutesError);
+
+    // エラーの種類に応じたメッセージ
+    const errorMessage =
+      minutesError.code === 'PGRST116'
+        ? 'アクセス権限がありません。ログイン状態を確認してください。'
+        : minutesError.message?.includes('network')
+          ? 'ネットワークエラーが発生しました。インターネット接続を確認してください。'
+          : '議事録の取得に失敗しました。しばらく経ってから再度お試しください。';
+
     return (
       <div className="max-w-6xl mx-auto p-4 sm:p-6">
         <div className="mb-6 sm:mb-8 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
@@ -74,9 +84,13 @@ export default async function MinutesListPage({
             <Link href={ROUTES.MINUTES_NEW}>新規議事録作成</Link>
           </Button>
         </div>
-        <div className="text-center py-12 text-red-600 dark:text-red-400">
-          <p className="mb-4">議事録の取得に失敗しました。</p>
-          <p className="text-sm">しばらく経ってから再度お試しください。</p>
+        <div className="text-center py-12" role="alert" aria-live="polite">
+          <p className="mb-4 text-red-600 dark:text-red-400 font-semibold">
+            {errorMessage}
+          </p>
+          <Button asChild className="mt-4">
+            <Link href={ROUTES.MINUTES_NEW}>新しい議事録を作成する</Link>
+          </Button>
         </div>
       </div>
     );
@@ -98,6 +112,9 @@ export default async function MinutesListPage({
           <Link href={ROUTES.MINUTES_NEW}>新規議事録作成</Link>
         </Button>
       </div>
+
+      {/* 使い方・注意事項 */}
+      <UsageGuide />
 
       {/* 検索フォーム */}
       <SearchForm />

--- a/components/usage-guide.tsx
+++ b/components/usage-guide.tsx
@@ -1,0 +1,44 @@
+/**
+ * 使い方・注意事項コンポーネント
+ * Issue 33: トップページへ使い方・注意事項を記載
+ */
+export function UsageGuide() {
+  return (
+    <div className="mb-6 p-4 sm:p-6 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800">
+      <h2 className="text-lg sm:text-xl font-semibold mb-4 text-blue-900 dark:text-blue-100">
+        使い方
+      </h2>
+      <ol className="list-decimal list-inside space-y-2 text-sm sm:text-base text-blue-800 dark:text-blue-200 mb-6">
+        <li>チームを作成、または招待リンクからチームに参加します</li>
+        <li>
+          スマホなどで録音した音声を、ChatGPTやGeminiなどの文字起こし対応AIサービスで文字起こしし、そのテキストを貼り付けます
+        </li>
+        <li>議事録を保存します</li>
+      </ol>
+
+      <div className="mb-6 p-3 sm:p-4 bg-white dark:bg-gray-800 rounded border border-blue-100 dark:border-blue-700">
+        <h3 className="text-sm sm:text-base font-semibold mb-2 text-gray-900 dark:text-gray-100 flex items-center gap-2">
+          <span className="text-xl" role="img" aria-label="補足">
+            💡
+          </span>
+          <span>補足</span>
+        </h3>
+        <p className="text-xs sm:text-sm text-gray-700 dark:text-gray-300">
+          要約とアクションプランは、保存後の議事録画面で各ボタンを押すことで生成されます
+        </p>
+      </div>
+
+      <div className="p-3 sm:p-4 bg-amber-50 dark:bg-amber-900/20 rounded border border-amber-200 dark:border-amber-800">
+        <h3 className="text-sm sm:text-base font-semibold mb-2 text-amber-900 dark:text-amber-100 flex items-center gap-2">
+          <span className="text-xl" role="img" aria-label="注意">
+            ⚠️
+          </span>
+          <span>注意</span>
+        </h3>
+        <p className="text-xs sm:text-sm text-amber-800 dark:text-amber-200">
+          要約・アクションプランの生成、編集、削除は議事録の作成者のみが行えます
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Issue 33の要件に従い、議事録一覧ページに使い方・補足・注意事項を追加しました。

変更内容:
- components/usage-guide.tsx を新規作成（使い方・注意事項コンポーネント）
- app/protected/minutes/page.tsx に UsageGuide コンポーネントを追加
- エラーハンドリングを改善（エラー種別に応じた具体的なメッセージ）
- アクセシビリティ向上（絵文字に aria-label 追加、role="alert" 追加）

コードレビュー対応:
- [CP-01] コンポーネント分離: UsageGuide を別コンポーネントに分離
- [AC-01] アクセシビリティ: 絵文字に role="img" と aria-label を追加
- [AC-01] セマンティック改善: br タグを削除し自然な改行に変更
- [ER-01] エラーハンドリング: エラー種別に応じた具体的なメッセージに改善

🤖 Generated with [Claude Code](https://claude.com/claude-code)